### PR TITLE
Fix error when using -unittest in another project with vwindow as a dependency

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -24,7 +24,8 @@
             "targetType": "autodetect",
             "dependencies": {
                 "aurorafw:unit": "0.0.1-alpha.4"
-			}
+			},
+            "versions": ["vwindow_unittest"]
         }
     ]
 }

--- a/source/vwindow/window.d
+++ b/source/vwindow/window.d
@@ -11,7 +11,7 @@ import std.traits : isFunctionPointer, isDelegate, ReturnType, Parameters;
 import bindbc.glfw.bindstatic;
 import bindbc.glfw.types;
 
-version(unittest) import aurorafw.unit.assertion;
+version(vwindow_unittest) import aurorafw.unit.assertion;
 
 
 /**


### PR DESCRIPTION
Running a project with `-unittest` was causing a dependency error because `vwindow` was using `aurorafw:unit` as dependency and importing it inside `version(unittest)`.